### PR TITLE
fix: convert loaderState to self-contained class in .ts file

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "svelte-check": "^3.6.6",
     "tslib": "^2.6.2",
     "typescript": "^5.3.3",
+    "typescript-svelte-plugin": "^0.3.37",
     "vite": "^5.1.4",
     "vitest": "^1.3.1"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ devDependencies:
   typescript:
     specifier: ^5.3.3
     version: 5.3.3
+  typescript-svelte-plugin:
+    specifier: ^0.3.37
+    version: 0.3.37(svelte@5.0.0-next.70)(typescript@5.3.3)
   vite:
     specifier: ^5.1.4
     version: 5.1.4
@@ -2369,6 +2372,16 @@ packages:
   /type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
+    dev: true
+
+  /typescript-svelte-plugin@0.3.37(svelte@5.0.0-next.70)(typescript@5.3.3):
+    resolution: {integrity: sha512-eg+uod/Ao6PEQ606DpexbbKF9Rzm3w8W53DyVFaNnR1CTmQQ4LbKwjcVqFhwFnGeXqrvB+0UK3atTaE+HyK0uA==}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
+      svelte2tsx: 0.7.3(svelte@5.0.0-next.70)(typescript@5.3.3)
+    transitivePeerDependencies:
+      - svelte
+      - typescript
     dev: true
 
   /typescript@5.3.3:

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,4 @@
-import InfiniteLoader, { loaderState } from "./InfiniteLoader.svelte"
+import InfiniteLoader from "./InfiniteLoader.svelte"
+import { loaderState } from "./loaderState.svelte"
 
 export { InfiniteLoader, loaderState }

--- a/src/lib/loaderState.svelte.ts
+++ b/src/lib/loaderState.svelte.ts
@@ -1,0 +1,29 @@
+export const STATUS = {
+  READY: "READY",
+  LOADING: "LOADING",
+  COMPLETE: "COMPLETE",
+  ERROR: "ERROR"
+} as const
+
+class LoaderState {
+  isFirstLoad = $state(true)
+  status = $state<keyof typeof STATUS>(STATUS.READY)
+
+  loaded = () => {
+    this.isFirstLoad = false
+    this.status = STATUS.READY
+  }
+  complete = () => {
+    this.isFirstLoad = false
+    this.status = STATUS.COMPLETE
+  }
+  reset = () => {
+    this.isFirstLoad = true
+    this.status = STATUS.READY
+  }
+  error = () => {
+    this.status = STATUS.ERROR
+  }
+}
+
+export const loaderState = new LoaderState()

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -69,7 +69,11 @@
         <strong>Warning</strong>: 10% of requests will <span class="warning-text">fail</span>
       </span>
     </p>
-    <InfiniteLoader triggerLoad={loadMore} loopDetectionTimeout={7500} intersectionOptions={{ root: rootElement }}>
+    <InfiniteLoader
+      triggerLoad={loadMore}
+      loopDetectionTimeout={7500}
+      intersectionOptions={{ root: rootElement }}
+    >
       {#each allItems as user (user.id)}
         <UserCard {user} />
       {/each}

--- a/src/routes/api/data/+server.ts
+++ b/src/routes/api/data/+server.ts
@@ -14,7 +14,7 @@ export const GET: RequestHandler = async ({ url }: RequestEvent) => {
     await wait(1000)
 
     // Randomly fail 10% of the time
-    if (Math.random() < 0.1) {
+    if (Math.random() < 0.5) {
       return new Response(null, { status: 500, statusText: "Randomly failing.." })
     }
 


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Remove the extra `<script context="module">...` in the `InfiniteLoader.svelte` and control that state in a separate .ts file and class singleton.

### Linked Issues

<!-- i.e. `Fixes #123` -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
